### PR TITLE
Swift 6へのアップグレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Develop image
 # ================================
-FROM swift:5.9.2-focal as develop
+FROM swift:6.0.0-jammy as develop
 
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -37,7 +37,7 @@ RUN [ -d /develop/Resources ] && { mv /develop/Resources ./Resources && chmod -R
 # ================================
 # Run image
 # ================================
-FROM swift:5.9.2-focal-slim
+FROM swift:6.0.0-jammy-slim
 
 # Make sure all system packages are up to date.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,241 +1,321 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "async-http-client",
-        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
-        "state": {
-          "branch": null,
-          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
-          "version": "1.9.0"
-        }
-      },
-      {
-        "package": "async-kit",
-        "repositoryURL": "https://github.com/vapor/async-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "e2f741640364c1d271405da637029ea6a33f754e",
-          "version": "1.11.1"
-        }
-      },
-      {
-        "package": "console-kit",
-        "repositoryURL": "https://github.com/vapor/console-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "75ea3b627d88221440b878e5dfccc73fd06842ed",
-          "version": "4.2.7"
-        }
-      },
-      {
-        "package": "fluent",
-        "repositoryURL": "https://github.com/vapor/fluent.git",
-        "state": {
-          "branch": null,
-          "revision": "ea707ee318066a073c95b2b2df1aa640fcb67f9e",
-          "version": "4.4.0"
-        }
-      },
-      {
-        "package": "fluent-kit",
-        "repositoryURL": "https://github.com/vapor/fluent-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "6fc2804a4d8b3f8a66f2d4bb3e3789aac3abd53d",
-          "version": "1.23.5"
-        }
-      },
-      {
-        "package": "fluent-postgres-driver",
-        "repositoryURL": "https://github.com/vapor/fluent-postgres-driver.git",
-        "state": {
-          "branch": null,
-          "revision": "7c266b539f71331ad6e53ea8fae587ccdaf972f2",
-          "version": "2.2.6"
-        }
-      },
-      {
-        "package": "Kanna",
-        "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
-        "state": {
-          "branch": null,
-          "revision": "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
-          "version": "5.2.7"
-        }
-      },
-      {
-        "package": "leaf",
-        "repositoryURL": "https://github.com/vapor/leaf.git",
-        "state": {
-          "branch": null,
-          "revision": "41741b782ac49959af2f7612661154326ac24d00",
-          "version": "4.1.5"
-        }
-      },
-      {
-        "package": "leaf-kit",
-        "repositoryURL": "https://github.com/vapor/leaf-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "949270ec003d34c72a592817d0c1dcdfc05726ae",
-          "version": "1.5.0"
-        }
-      },
-      {
-        "package": "multipart-kit",
-        "repositoryURL": "https://github.com/vapor/multipart-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "2dd9368a3c9580792b77c7ef364f3735909d9996",
-          "version": "4.5.1"
-        }
-      },
-      {
-        "package": "postgres-kit",
-        "repositoryURL": "https://github.com/vapor/postgres-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "35deea5c28a7d402f3280d81dee37bed5c56b9fe",
-          "version": "2.8.3"
-        }
-      },
-      {
-        "package": "postgres-nio",
-        "repositoryURL": "https://github.com/vapor/postgres-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "d648c5b4594ffbc2f6173318f70f5531e05ccb4e",
-          "version": "1.11.0"
-        }
-      },
-      {
-        "package": "routing-kit",
-        "repositoryURL": "https://github.com/vapor/routing-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "5603b81ceb744b8318feab1e60943704977a866b",
-          "version": "4.3.1"
-        }
-      },
-      {
-        "package": "sql-kit",
-        "repositoryURL": "https://github.com/vapor/sql-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "89b0a0a5f110e77272fb5a775064a31bfc1f155c",
-          "version": "3.18.0"
-        }
-      },
-      {
-        "package": "swift-atomics",
-        "repositoryURL": "https://github.com/apple/swift-atomics.git",
-        "state": {
-          "branch": null,
-          "revision": "cd142fd2f64be2100422d658e7411e39489da985",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "swift-backtrace",
-        "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
-        "state": {
-          "branch": null,
-          "revision": "d3e04a9d4b3833363fb6192065b763310b156d54",
-          "version": "1.3.1"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "067254c79435de759aeef4a6a03e43d087d61312",
-          "version": "2.0.5"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
-        }
-      },
-      {
-        "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics.git",
-        "state": {
-          "branch": null,
-          "revision": "eadb828f878fed144387e3845866225bb7082c56",
-          "version": "2.3.0"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "d0f261ddd9eb8694290c09a16e18a00c76846182",
-          "version": "2.39.1"
-        }
-      },
-      {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
-        "state": {
-          "branch": null,
-          "revision": "d02584d64bfe3cf722f9b3b3ea5301f6c7109e77",
-          "version": "1.10.3"
-        }
-      },
-      {
-        "package": "swift-nio-http2",
-        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
-        "state": {
-          "branch": null,
-          "revision": "50c25c132b140e62b45e90b5a76f13ded02c8a46",
-          "version": "1.20.1"
-        }
-      },
-      {
-        "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
-        "state": {
-          "branch": null,
-          "revision": "b5260a31c2a72a89fa684f5efb3054d8725a2316",
-          "version": "2.18.0"
-        }
-      },
-      {
-        "package": "swift-nio-transport-services",
-        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
-        "state": {
-          "branch": null,
-          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
-          "version": "1.11.4"
-        }
-      },
-      {
-        "package": "vapor",
-        "repositoryURL": "https://github.com/vapor/vapor.git",
-        "state": {
-          "branch": null,
-          "revision": "b05266f863ee93eeff4b6d075364ccc8f81bbc1e",
-          "version": "4.57.0"
-        }
-      },
-      {
-        "package": "websocket-kit",
-        "repositoryURL": "https://github.com/vapor/websocket-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "e32033ad3c68ebec1b761bc961be7bd56bad02f8",
-          "version": "2.3.1"
-        }
+  "originHash" : "c56926396b8ccb07df1dfb979e46456ee6d275939d5acd1bf60f7834bef3766c",
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "333f51104b75d1a5b94cb3b99e4c58a3b442c9f7",
+        "version" : "1.25.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "async-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/async-kit.git",
+      "state" : {
+        "revision" : "e048c8ee94967e8d8a1c2ec0e1156d6f7fa34d31",
+        "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "console-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/console-kit.git",
+      "state" : {
+        "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
+        "version" : "4.15.2"
+      }
+    },
+    {
+      "identity" : "fluent",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/fluent.git",
+      "state" : {
+        "revision" : "223b27d04ab2b51c25503c9922eecbcdf6c12f89",
+        "version" : "4.12.0"
+      }
+    },
+    {
+      "identity" : "fluent-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/fluent-kit.git",
+      "state" : {
+        "revision" : "788f4b92c8d96e2bc0b89f6a240fa873d437c105",
+        "version" : "1.51.0"
+      }
+    },
+    {
+      "identity" : "fluent-postgres-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/fluent-postgres-driver.git",
+      "state" : {
+        "revision" : "fd57101e426d3edf66a32ba63a7d0b8ced4d7499",
+        "version" : "2.10.0"
+      }
+    },
+    {
+      "identity" : "kanna",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tid-kijyun/Kanna.git",
+      "state" : {
+        "revision" : "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
+        "version" : "5.2.7"
+      }
+    },
+    {
+      "identity" : "leaf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/leaf.git",
+      "state" : {
+        "revision" : "bf48d2423c00292b5937c60166c7db99705cae47",
+        "version" : "4.4.1"
+      }
+    },
+    {
+      "identity" : "leaf-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/leaf-kit.git",
+      "state" : {
+        "revision" : "902c51288a6a1c3f19d9e33d1aebee066364c0e6",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "multipart-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/multipart-kit.git",
+      "state" : {
+        "revision" : "3a31859efeb054cdcd407fe152802ddc5c58bbce",
+        "version" : "4.5.3"
+      }
+    },
+    {
+      "identity" : "postgres-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/postgres-kit.git",
+      "state" : {
+        "revision" : "f4d4b9e8db9a907644d67d6a7ecb5f0314eec1ad",
+        "version" : "2.14.0"
+      }
+    },
+    {
+      "identity" : "postgres-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/postgres-nio.git",
+      "state" : {
+        "revision" : "5d817be55cae8b00003b7458944954558302d006",
+        "version" : "1.25.0"
+      }
+    },
+    {
+      "identity" : "routing-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/routing-kit.git",
+      "state" : {
+        "revision" : "8c9a227476555c55837e569be71944e02a056b72",
+        "version" : "4.9.1"
+      }
+    },
+    {
+      "identity" : "sql-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/sql-kit.git",
+      "state" : {
+        "revision" : "e0b35ff07601465dd9f3af19a1c23083acaae3bd",
+        "version" : "3.32.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "4c3ea81f81f0a25d0470188459c6d4bf20cf2f97",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "067254c79435de759aeef4a6a03e43d087d61312",
+        "version" : "2.0.5"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "a64a0abc2530f767af15dd88dda7f64d5f1ff9de",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "d01361d32e14ae9b70ea5bd308a3794a198a2706",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "44491db7cc66774ab930cf15f36324e16b06f425",
+        "version" : "2.6.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
+        "version" : "2.81.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "00f3f72d2f9942d0e2dc96057ab50a37ced150d4",
+        "version" : "1.25.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "170f4ca06b6a9c57b811293cebcb96e81b661310",
+        "version" : "1.35.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "0cc3528ff48129d64ab9cab0b1cd621634edfc6b",
+        "version" : "2.29.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "3c394067c08d1225ba8442e9cffb520ded417b64",
+        "version" : "1.23.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "8946c930cae601452149e45d31d8ddfac973c3c7",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "7ee57f99fbe0073c3700997186721e74d925b59b",
+        "version" : "2.7.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
+        "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/vapor.git",
+      "state" : {
+        "revision" : "87b0edd2633c35de543cb7573efe5fbf456181bc",
+        "version" : "4.114.1"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit.git",
+      "state" : {
+        "revision" : "4232d34efa49f633ba61afde365d3896fc7f8740",
+        "version" : "2.15.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,20 @@
-// swift-tools-version:5.5
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
     name: "agqr-program-guide",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v14)
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
-        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
-        .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.1"),
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.8.0"),
+        .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.8.0"),
+        .package(url: "https://github.com/vapor/leaf.git", from: "4.2.4"),
+        .package(url: "https://github.com/vapor/multipart-kit.git", exact: "4.5.3"),
         // HTML Parser
-        .package(url: "https://github.com/tid-kijyun/Kanna.git", .upToNextMajor(from: "5.2.4"))
+        .package(url: "https://github.com/tid-kijyun/Kanna.git", .upToNextMajor(from: "5.2.7"))
     ],
     targets: [
         .target(
@@ -33,7 +34,7 @@ let package = Package(
                 .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
             ]
         ),
-        .target(name: "Run", dependencies: [.target(name: "App")]),
+        .executableTarget(name: "Run", dependencies: [.target(name: "App")]),
         .testTarget(name: "AppTests", dependencies: [
             .target(name: "App"),
             .product(name: "XCTVapor", package: "vapor"),

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,6 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "4.8.0"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.8.0"),
         .package(url: "https://github.com/vapor/leaf.git", from: "4.2.4"),
-        .package(url: "https://github.com/vapor/multipart-kit.git", exact: "4.5.3"),
         // HTML Parser
         .package(url: "https://github.com/tid-kijyun/Kanna.git", .upToNextMajor(from: "5.2.7"))
     ],

--- a/Sources/App/Migrations/CreateProgram.swift
+++ b/Sources/App/Migrations/CreateProgram.swift
@@ -7,7 +7,7 @@ struct CreateProgram: Migration {
         return database.schema(self.tableName)
             .field("id", .int, .identifier(auto: true))
             .field("title", .string, .required)
-            .field("info", .sql(raw: "TEXT"), .required)
+            .field("info", .sql(unsafeRaw: "TEXT"), .required)
             .field("url", .string, .required)
             .field("start_datetime", .datetime, .required)
             .field("end_datetime", .datetime, .required)

--- a/Sources/App/Models/Personality.swift
+++ b/Sources/App/Models/Personality.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Vapor
 
-final class Personality: Model, Content {
+final class Personality: Model, Content, @unchecked Sendable {
     static let schema = "personalities"
 
     @ID(custom: "id")

--- a/Sources/App/Models/Program.swift
+++ b/Sources/App/Models/Program.swift
@@ -2,7 +2,7 @@ import Fluent
 import Foundation
 import Vapor
 
-final class Program: Model, Content {
+final class Program: Model, Content, @unchecked Sendable {
     static let schema = "programs"
 
     @ID(custom: "id")

--- a/Sources/App/Models/ProgramPersonality.swift
+++ b/Sources/App/Models/ProgramPersonality.swift
@@ -1,6 +1,6 @@
 import Fluent
 
-final class ProgramPersonality: Model {
+final class ProgramPersonality: Model, @unchecked Sendable {
     static let schema = "programs+personalities"
 
     @ID(custom: "id")

--- a/Sources/App/Repositories/ProgramGuideRepository.swift
+++ b/Sources/App/Repositories/ProgramGuideRepository.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Vapor
 
-protocol ProgramGuideSaving {
+protocol ProgramGuideSaving: Sendable {
     func save(_ items: [ProgramGuide], app: Application) async
 }
 

--- a/Sources/App/Services/DailyProgramGuideParser.swift
+++ b/Sources/App/Services/DailyProgramGuideParser.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Kanna
 
-protocol ProgramGuideParsing {
+protocol ProgramGuideParsing: Sendable {
     func parse(_ content: Data) throws -> [ProgramGuide]
 }
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -10,24 +10,24 @@ public func configure(_ app: Application) throws {
     // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     
     // SSL設定
-    let tlsConfig: TLSConfiguration?
+    let tls: PostgresConnection.Configuration.TLS
     if Environment.get("DATABASE_USE_SSL") == "true" {
-        var config = TLSConfiguration.makeClientConfiguration()
-        config.certificateVerification = .none
-        tlsConfig = config
+        tls = .prefer(try .init(configuration: .clientDefault))
     } else {
-        tlsConfig = nil
+        tls = .disable
     }
     
+    let configuration = SQLPostgresConfiguration(
+        hostname: Environment.get("DATABASE_HOST") ?? "localhost",
+        port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? SQLPostgresConfiguration.ianaPortNumber,
+        username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
+        password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
+        database: Environment.get("DATABASE_NAME") ?? "vapor_database",
+        tls: tls
+    )
+    
     app.databases.use(
-        .postgres(
-            hostname: Environment.get("DATABASE_HOST") ?? "localhost",
-            port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? PostgresConfiguration.ianaPortNumber,
-            username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
-            password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
-            database: Environment.get("DATABASE_NAME") ?? "vapor_database",
-            tlsConfiguration: tlsConfig
-        ),
+        .postgres(configuration: configuration),
         as: .psql
     )
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -12,7 +12,9 @@ public func configure(_ app: Application) throws {
     // SSL設定
     let tls: PostgresConnection.Configuration.TLS
     if Environment.get("DATABASE_USE_SSL") == "true" {
-        tls = .prefer(try .init(configuration: .clientDefault))
+        var config = TLSConfiguration.makeClientConfiguration()
+        config.certificateVerification = .none
+        tls = .prefer(try .init(configuration: config))
     } else {
         tls = .disable
     }

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -1,11 +1,8 @@
 import App
 import Vapor
 
-// Using synchronous API because of restrictions in Swift 6
-// for using shutdown in async contexts
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
-let app = Application(env)
-defer { app.shutdown() }
+let app = try await Application.make(env)
 try configure(app)
-try app.run()
+try await app.execute()

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -1,6 +1,8 @@
 import App
 import Vapor
 
+// Using synchronous API because of restrictions in Swift 6
+// for using shutdown in async contexts
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
 let app = Application(env)

--- a/Tests/AppTests/Controllers/ControllerBaseTestCase.swift
+++ b/Tests/AppTests/Controllers/ControllerBaseTestCase.swift
@@ -2,18 +2,16 @@
 import XCTVapor
 
 class ControllerBaseTestCase: XCTestCase {
-    let app: Application = Application(.testing)
+    let app = Application(.testing)
 
-    override func setUp() async throws {
-        try await super.setUp()
-        try configure(app)
-        try app.migrator.setupIfNeeded().wait()
-        try app.migrator.prepareBatch().wait()
+    override func setUp() {
+        try! configure(app)
+        try! app.migrator.setupIfNeeded().wait()
+        try! app.migrator.prepareBatch().wait()
     }
 
-    override func tearDown() async throws {
-        try app.migrator.revertAllBatches().wait()
+    override func tearDown() {
+        try! app.migrator.revertAllBatches().wait()
         app.shutdown()
-        try await super.tearDown()
     }
 }

--- a/Tests/AppTests/Controllers/NowTests.swift
+++ b/Tests/AppTests/Controllers/NowTests.swift
@@ -2,13 +2,13 @@
 import XCTVapor
 
 final class NowTests: ControllerBaseTestCase {
-    func testAPINow() async throws {
+    func testAPINow() throws {
         let program = Program(title: "sample", info: "info", url: "http://example.com/", startDatetime: Calendar.current.date(byAdding: .minute, value: -5, to: Date())!, endDatetime: Calendar.current.date(byAdding: .minute, value: 5, to: Date())!, dur: 10, isRepeat: false, isMovie: false, isLive: true)
-        try await program.save(on: app.db).get()
+        try program.save(on: app.db).wait()
 
         try app.test(.GET, "/api/now", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertContains(res.body.string, "sample") // MEMO: 募 定義のないjsonをいい感じに扱う方法
+            XCTAssertContains(res.body.string, "sample")
         })
     }
 }


### PR DESCRIPTION
Swift 6へのアップグレードを行いました。

## 変更内容
- Package.swiftのswift-tools-versionを6.0に更新
- DockerfileのSwiftイメージを6.0.0に更新
- モデルクラスをSendableに準拠させる修正
- プロトコルをSendableに準拠させる修正
- 非推奨APIの更新（PostgresConfiguration → SQLPostgresConfiguration）
- テストコードの修正

ビルドが成功することを確認しています。